### PR TITLE
Show other tickets from email

### DIFF
--- a/admin/admin_ticket.php
+++ b/admin/admin_ticket.php
@@ -640,6 +640,26 @@ if ( defined('HESK_DEMO') )
 	$ticket['ip']	 = '127.0.0.1';
 }
 
+// If an email address is tied to this ticket, check if there are any others
+$recentTickets = NULL;
+if($ticket['email'] != '') {
+    $recentTicketsSql = hesk_dbQuery("SELECT * FROM `".hesk_dbEscape($hesk_settings['db_pfix'])."tickets`
+    WHERE `email` = '".hesk_dbEscape($ticket['email'])."' AND `trackid` <> '".hesk_dbEscape($trackingID)."' ORDER BY `lastchange` DESC LIMIT 5");
+    while ($recentRow = hesk_dbFetchAssoc($recentTicketsSql)) {
+        if ($recentTickets === NULL) {
+            $recentTickets = array();
+        }
+        array_push($recentTickets, $recentRow);
+    }
+
+    foreach ($recentTickets as $recentTicket) {
+        $thisTicketStatusRS = hesk_dbQuery("SELECT * FROM `".hesk_dbEscape($hesk_settings['db_pfix'])."statuses` WHERE `ID` = ".intval($recentTicket['status']));
+        $theStatusRow = hesk_dbFetchAssoc($thisTicketStatusRS);
+        $recentTicket['statusText'] = $hesklang[$theStatusRow['ShortNameContentKey']];
+        $recentTicket['statusColor'] = $theStatusRow['TextColor'];
+    }
+}
+
 /* Print admin navigation */
 require_once(HESK_PATH . 'inc/show_admin_nav.inc.php');
 ?>
@@ -789,6 +809,17 @@ require_once(HESK_PATH . 'inc/show_admin_nav.inc.php');
                     </div>
                     <?php } ?>
                 </li>
+                <?php if ($recentTickets != NULL): ?>
+                    <li class="list-group-item">
+                        <strong><?php echo $hesklang['recent_tickets']; ?></strong>
+                        <?php foreach ($recentTickets as $recentTicket): ?>
+                            <p style="margin: 0">
+                                <i class="fa fa-circle"></i>
+                                <?php echo $recentTicket['trackid']; ?>
+                            </p>
+                        <?php endforeach; ?>
+                    </li>
+                <?php endif; ?>
             </ul>
         </div>
     </div>

--- a/admin/admin_ticket.php
+++ b/admin/admin_ticket.php
@@ -652,11 +652,17 @@ if($ticket['email'] != '') {
         array_push($recentTickets, $recentRow);
     }
 
-    foreach ($recentTickets as $recentTicket) {
-        $thisTicketStatusRS = hesk_dbQuery("SELECT * FROM `".hesk_dbEscape($hesk_settings['db_pfix'])."statuses` WHERE `ID` = ".intval($recentTicket['status']));
-        $theStatusRow = hesk_dbFetchAssoc($thisTicketStatusRS);
-        $recentTicket['statusText'] = $hesklang[$theStatusRow['ShortNameContentKey']];
-        $recentTicket['statusColor'] = $theStatusRow['TextColor'];
+    if ($recentTickets !== NULL) {
+        $recentTicketsWithStatuses = array();
+        foreach ($recentTickets as $recentTicket) {
+            $newRecentTicket = $recentTicket;
+            $thisTicketStatusRS = hesk_dbQuery("SELECT * FROM `" . hesk_dbEscape($hesk_settings['db_pfix']) . "statuses` WHERE `ID` = " . intval($recentTicket['status']));
+            $theStatusRow = hesk_dbFetchAssoc($thisTicketStatusRS);
+            $newRecentTicket['statusText'] = $hesklang[$theStatusRow['ShortNameContentKey']];
+            $newRecentTicket['statusColor'] = $theStatusRow['TextColor'];
+            array_push($recentTicketsWithStatuses, $newRecentTicket);
+        }
+        $recentTickets = $recentTicketsWithStatuses;
     }
 }
 
@@ -809,13 +815,15 @@ require_once(HESK_PATH . 'inc/show_admin_nav.inc.php');
                     </div>
                     <?php } ?>
                 </li>
-                <?php if ($recentTickets != NULL): ?>
+                <?php if ($recentTickets !== NULL): ?>
                     <li class="list-group-item">
                         <strong><?php echo $hesklang['recent_tickets']; ?></strong>
                         <?php foreach ($recentTickets as $recentTicket): ?>
                             <p style="margin: 0">
-                                <i class="fa fa-circle"></i>
-                                <?php echo $recentTicket['trackid']; ?>
+                                <i class="fa fa-circle" data-toggle="tooltip" data-placement="top"
+                                   style="color: <?php echo $recentTicket['statusColor']; ?>"
+                                   title="<?php echo sprintf($hesklang['current_status_colon'], $recentTicket['statusText']); ?>"></i>
+                                <?php echo '<a href="admin_ticket.php?track='.$recentTicket['trackid'].'&amp;Refresh='.mt_rand(10000,99999).'">'.$recentTicket['trackid'].'</a>'; ?>
                             </p>
                         <?php endforeach; ?>
                     </li>

--- a/language/en/text.php
+++ b/language/en/text.php
@@ -59,6 +59,7 @@ $hesklang['staff_only'] = 'Staff only';
 $hesklang['yes_title_case'] = 'Yes';
 $hesklang['no_title_case'] = 'No';
 $hesklang['autoclose_ticket_status'] = 'When a ticket is closed automatically, change the status to';
+$hesklang['recent_tickets'] = 'Recent tickets';
 
 // ADDED OR MODIFIED IN Mods for HESK 2.1.1
 $hesklang['new_article_default_type'] = 'Default Type for New Articles';

--- a/language/en/text.php
+++ b/language/en/text.php
@@ -60,6 +60,7 @@ $hesklang['yes_title_case'] = 'Yes';
 $hesklang['no_title_case'] = 'No';
 $hesklang['autoclose_ticket_status'] = 'When a ticket is closed automatically, change the status to';
 $hesklang['recent_tickets'] = 'Recent tickets';
+$hesklang['current_status_colon'] = 'Current status: %s'; // %s: status name (i.e. "Resolved", "New", etc.)
 
 // ADDED OR MODIFIED IN Mods for HESK 2.1.1
 $hesklang['new_article_default_type'] = 'Default Type for New Articles';


### PR DESCRIPTION
Closes #153 - shows 5 most recent tickets from the email address that submitted the ticket that the user is currently looking at. Shows the current status of the ticket as a "light" (and tooltip), and supplies a link to the ticket. Nothing fancy.