### PR TITLE
Fix Reset Password Page

### DIFF
--- a/admin/password.php
+++ b/admin/password.php
@@ -172,7 +172,6 @@ elseif (isset($_GET['h'])) {
     $hash = preg_replace('/[^a-zA-Z0-9]/', '', $_GET['h']);
 
     // Connect to database
-    hesk_load_database_functions();
     hesk_dbConnect();
 
     // Expire verification hashes older than 2 hours


### PR DESCRIPTION
Remove the extra `hesk_load_database_functions()` call to prevent a white screen error. Fixes #423