### PR TITLE
Fix banned emails

### DIFF
--- a/admin/banned_emails.php
+++ b/admin/banned_emails.php
@@ -207,7 +207,7 @@ require_once(HESK_PATH . 'inc/show_admin_nav.inc.php');
 
                         if ($can_unban) {
                             echo '
-                            <td class="' . $color . ' text-left>
+                            <td class="' . $color . ' text-left">
                                 <a href="banned_emails.php?a=unban&amp;id=' . $ban['id'] . '&amp;token=' . hesk_token_echo(0) . '" onclick="return confirm_delete();">
                                     <i class="fa fa-times red font-size-16p" data-toggle="tooltip" data-placement="top" data-original-title="' . $hesklang['delban'] . '"></i>
                                 </a>


### PR DESCRIPTION
There was a missing double quote (`"`) that caused invalid markup. Closes #416